### PR TITLE
Fix/preserve newline at end of notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ pre-commit hook to remove cell output of .ipynb notebook and some metadata for b
 Sample config:
 ```
 repos:
-  - repo: https://github.com/aflc/pre-commit-jupyter
-    rev: v1.0.0
+  - repo: https://github.com/roy-ht/pre-commit-jupyter
+    rev: v1.2.0
     hooks:
       - id: jupyter-notebook-cleanup
         args:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ pre-commit hook to remove cell output of .ipynb notebook and some metadata for b
 Sample config:
 ```
 repos:
-  - repo: https://github.com/rjdrenth/pre-commit-jupyter
-    rev: v1.2.1
+  - repo: https://github.com/roy-ht/pre-commit-jupyter
+    rev: v1.2.0
     hooks:
       - id: jupyter-notebook-cleanup
         args:

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ pre-commit hook to remove cell output of .ipynb notebook and some metadata for b
 Sample config:
 ```
 repos:
-  - repo: https://github.com/roy-ht/pre-commit-jupyter
-    rev: v1.2.0
+  - repo: https://github.com/rjdrenth/pre-commit-jupyter
+    rev: v1.2.1
     hooks:
       - id: jupyter-notebook-cleanup
         args:
-          - --remove-kernel-metadata
+          # - --remove-kernel-metadata
           - --pin-patterns
           - "[pin];[donotremove]"
 ```

--- a/jupyter_notebook_cleanup/cli.py
+++ b/jupyter_notebook_cleanup/cli.py
@@ -49,7 +49,7 @@ def remove_output_file(path, patterns, remove_kernel_metadata, preview):
             data = json.load(f, object_pairs_hook=OrderedDict)
         new_data = remove_output_object(data, patterns, remove_kernel_metadata)
         before_j = json.dumps(data, **dump_args)
-        after_j = json.dumps(new_data, **dump_args)
+        after_j = json.dumps(new_data, **dump_args) + "\n"
         if preview:
             before_l, after_l = before_j.splitlines(), after_j.splitlines()
             print("\n".join(difflib.unified_diff(before_l, after_l, fromfile="before", tofile="after")))
@@ -57,6 +57,7 @@ def remove_output_file(path, patterns, remove_kernel_metadata, preview):
             if before_j != after_j:  # overwrite to the original file
                 with open(path, "wt", encoding="utf-8") as fo:
                     json.dump(new_data, fo, **dump_args)
+                    fo.write("\n")
         shutil.copystat(tpath, path)  # copy original timestamps
 
 

--- a/jupyter_notebook_cleanup/cli.py
+++ b/jupyter_notebook_cleanup/cli.py
@@ -45,7 +45,7 @@ def remove_output_file(path, patterns, remove_kernel_metadata, preview):
     with tempfile.TemporaryDirectory() as tdir:
         tpath = os.path.join(tdir, "jupyter-notebook-cleanup-" + str(uuid.uuid1()))
         shutil.copy2(path, tpath)
-        with open(path, "rt") as f:
+        with open(path, "rt", encoding="utf-8") as f:
             data = json.load(f, object_pairs_hook=OrderedDict)
         new_data = remove_output_object(data, patterns, remove_kernel_metadata)
         before_j = json.dumps(data, **dump_args)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jupyter-notebook-cleanup",
-    version="1.0.0",
+    version="1.2.1",
     description="Automagically remove notebook outputs for better security",
     author="Hiroyuki Tanaka",
     author_email="aflc0x@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jupyter-notebook-cleanup",
-    version="1.2.1",
+    version="1.2.0",
     description="Automagically remove notebook outputs for better security",
     author="Hiroyuki Tanaka",
     author_email="aflc0x@gmail.com",


### PR DESCRIPTION
By default Jupyter notebooks are stored with a newline at the end of the file. Furthermore, not including a newline will cause the pre-commit hook 'end-of-file-fixer' to fail and add a newline. This triggers a never-ending loop of fails. 

This fix will ensure that any adjusted notebook does include a newline at the end of the file, preserving original behaviour when Jupyter saves a notebook and reducing interference with other pre-commit hooks.
